### PR TITLE
Update badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # grpc-connect-go-errors
 
 [![Keep a Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog-%23E05735)](CHANGELOG.md)
-[![GitHub Release](https://img.shields.io/github/v/release/github.com/franchb/grpc-connect-go-errors)](https://github.com/franchb/grpc-connect-go-errors/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/franchb/grpc-connect-go-errors.svg)](https://pkg.go.dev/github.com/franchb/grpc-connect-go-errors)
-[![go.mod](https://img.shields.io/github/go-mod/go-version/github.com/franchb/grpc-connect-go-errors)](go.mod)
-[![LICENSE](https://img.shields.io/github/license/github.com/franchb/grpc-connect-go-errors)](LICENSE)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/github.com/franchb/grpc-connect-go-errors/build.yml?branch=main)](https://github.com/franchb/grpc-connect-go-errors/actions?query=workflow%3Abuild+branch%3Amain)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/franchb/grpc-connect-go-errors)
+![GitHub License](https://img.shields.io/github/license/franchb/grpc-connect-go-errors)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/franchb/grpc-connect-go-errors/build.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/franchb/grpc-connect-go-errors)](https://goreportcard.com/report/github.com/franchb/grpc-connect-go-errors)
 [![Codecov](https://codecov.io/gh/franchb/grpc-connect-go-errors/branch/main/graph/badge.svg)](https://codecov.io/gh/franchb/grpc-connect-go-errors)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated badges in the README for go.mod version, license, and GitHub Actions workflow status. Removed the GitHub release badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->