### PR TITLE
Add support for transferring gRPC error details to Connect errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -22,8 +22,6 @@ func FromGRPCError(err error) error {
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
-
-
 	var result *connect.Error
 
 	//nolint:exhaustive // codes.OK returns always a nil error handled at the first line of function.
@@ -70,17 +68,6 @@ func FromGRPCError(err error) error {
 		result = connect.NewError(connect.CodeInternal, err)
 	}
 
-	details := make([]*connect.ErrorDetail, 0, len(errorStatus.Details()))
-	for detail := range slices.Values(errorStatus.Details()) {
-		msg, ok := detail.(proto.Message)
-		if !ok {
-			continue
-		}
-		errorDetail, errorDetailErr := connect.NewErrorDetail(msg)
-		if errorDetailErr == nil {
-			details = append(details, errorDetail)
-		}
-	}
 	for detail := range slices.Values(errorStatus.Details()) {
 		msg, ok := detail.(proto.Message)
 		if !ok {

--- a/error.go
+++ b/error.go
@@ -1,9 +1,12 @@
 package connectgrpcerr
 
 import (
+	"slices"
+
 	connect "connectrpc.com/connect"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // FromGRPCError maps the gRPC error to the corresponding connect-go error code.
@@ -19,6 +22,10 @@ func FromGRPCError(err error) error {
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
+
+
+	var result *connect.Error
+
 	//nolint:exhaustive // codes.OK returns always a nil error handled at the first line of function.
 	switch errorStatus.Code() {
 	// case codes.OK:
@@ -28,38 +35,61 @@ func FromGRPCError(err error) error {
 	// an OK status? (Also, the Connect protocol doesn't use a code for
 	// successes.)
 	case codes.Canceled:
-		return connect.NewError(connect.CodeCanceled, err)
+		result = connect.NewError(connect.CodeCanceled, err)
 	case codes.Unknown:
-		return connect.NewError(connect.CodeUnknown, err)
+		result = connect.NewError(connect.CodeUnknown, err)
 	case codes.InvalidArgument:
-		return connect.NewError(connect.CodeInvalidArgument, err)
+		result = connect.NewError(connect.CodeInvalidArgument, err)
 	case codes.DeadlineExceeded:
-		return connect.NewError(connect.CodeDeadlineExceeded, err)
+		result = connect.NewError(connect.CodeDeadlineExceeded, err)
 	case codes.NotFound:
-		return connect.NewError(connect.CodeNotFound, err)
+		result = connect.NewError(connect.CodeNotFound, err)
 	case codes.AlreadyExists:
-		return connect.NewError(connect.CodeAlreadyExists, err)
+		result = connect.NewError(connect.CodeAlreadyExists, err)
 	case codes.PermissionDenied:
-		return connect.NewError(connect.CodePermissionDenied, err)
+		result = connect.NewError(connect.CodePermissionDenied, err)
 	case codes.ResourceExhausted:
-		return connect.NewError(connect.CodeResourceExhausted, err)
+		result = connect.NewError(connect.CodeResourceExhausted, err)
 	case codes.FailedPrecondition:
-		return connect.NewError(connect.CodeFailedPrecondition, err)
+		result = connect.NewError(connect.CodeFailedPrecondition, err)
 	case codes.Aborted:
-		return connect.NewError(connect.CodeAborted, err)
+		result = connect.NewError(connect.CodeAborted, err)
 	case codes.OutOfRange:
-		return connect.NewError(connect.CodeOutOfRange, err)
+		result = connect.NewError(connect.CodeOutOfRange, err)
 	case codes.Unimplemented:
-		return connect.NewError(connect.CodeUnimplemented, err)
+		result = connect.NewError(connect.CodeUnimplemented, err)
 	case codes.Internal:
-		return connect.NewError(connect.CodeInternal, err)
+		result = connect.NewError(connect.CodeInternal, err)
 	case codes.Unavailable:
-		return connect.NewError(connect.CodeUnavailable, err)
+		result = connect.NewError(connect.CodeUnavailable, err)
 	case codes.DataLoss:
-		return connect.NewError(connect.CodeDataLoss, err)
+		result = connect.NewError(connect.CodeDataLoss, err)
 	case codes.Unauthenticated:
-		return connect.NewError(connect.CodeUnauthenticated, err)
+		result = connect.NewError(connect.CodeUnauthenticated, err)
 	default:
-		return connect.NewError(connect.CodeInternal, err)
+		result = connect.NewError(connect.CodeInternal, err)
 	}
+
+	details := make([]*connect.ErrorDetail, 0, len(errorStatus.Details()))
+	for detail := range slices.Values(errorStatus.Details()) {
+		msg, ok := detail.(proto.Message)
+		if !ok {
+			continue
+		}
+		errorDetail, errorDetailErr := connect.NewErrorDetail(msg)
+		if errorDetailErr == nil {
+			details = append(details, errorDetail)
+		}
+	}
+	for detail := range slices.Values(errorStatus.Details()) {
+		msg, ok := detail.(proto.Message)
+		if !ok {
+			continue
+		}
+		errorDetail, errorDetailErr := connect.NewErrorDetail(msg)
+		if errorDetailErr == nil {
+			result.AddDetail(errorDetail)
+		}
+	}
+	return result
 }

--- a/error_test.go
+++ b/error_test.go
@@ -8,6 +8,8 @@ import (
 	connect "connectrpc.com/connect"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	connectgrpcerr "github.com/franchb/grpc-connect-go-errors"
 )
@@ -72,5 +74,35 @@ func TestFromGRPCErrorCodeOK(t *testing.T) {
 	result := connectgrpcerr.FromGRPCError(original)
 	if result != nil {
 		t.Errorf("got %v, want nil", result)
+	}
+}
+
+func TestFromGRPCErrorWithDetails(t *testing.T) {
+	t.Parallel()
+
+	detail := structpb.NewNullValue()
+
+	errorStatus, err := status.New(codes.FailedPrecondition, "err msg").WithDetails(detail)
+	if err != nil {
+		t.Fatalf("got unexpected error %v", err)
+	}
+	result := connectgrpcerr.FromGRPCError(errorStatus.Err())
+	var connectErr *connect.Error
+	ok := errors.As(result, &connectErr)
+	if !ok {
+		t.Fatalf("got non-connect error %v", result)
+	}
+
+	details := connectErr.Details()
+	if len(details) != 1 {
+		t.Errorf("unexpected amount of details %d (expected 1)", len(details))
+	} else {
+		detailMsg, err := details[0].Value()
+		if err != nil {
+			t.Fatalf("unexpected error %v when getting detail", err)
+		}
+		if !proto.Equal(detail, detailMsg) {
+			t.Errorf("grpc detail is not equal to converted detail")
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/franchb/grpc-connect-go-errors
 
-go 1.22
+go 1.26.1
 
 require (
 	connectrpc.com/connect v1.16.2


### PR DESCRIPTION
Added support for details: now details from *status.Error are being transfered to *connect.Error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to extract and preserve structured error details from upstream errors.

* **Tests**
  * Added a unit test verifying error-detail extraction and protobuf equality for converted errors.

* **Chores**
  * Updated minimum Go toolchain requirement to 1.26.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->